### PR TITLE
Adding pending states to unconfirmed transactions

### DIFF
--- a/src/templates/tx.pug
+++ b/src/templates/tx.pug
@@ -9,7 +9,10 @@ block content
         .columns
           .column
             .blockFullLabel Received
-            .blockFullDetail=timeAgo(tx.time)
+            if tx.height === -1
+              .blockFullDetail Pending
+            else
+              .blockFullDetail=timeAgo(tx.time)
           .column
             .blockFullLabel Amount
             //- XXX This value is not accurate for real txs
@@ -36,7 +39,10 @@ block content
                   tr
                     td.stacked
                       span.stackedLabel Block Height
-                      a(href=`/block/${tx.height}`).stackedElement=tx.height
+                      if tx.height === -1
+                        .stackedElement Pending
+                      else
+                        a(href=`/block/${tx.height}`).stackedElement=tx.height
                   tr
                     td.stacked
                       span.stackedLabel Hex

--- a/src/util/templateFunctions.js
+++ b/src/util/templateFunctions.js
@@ -89,6 +89,7 @@ function numberWithCommas(x) {
 
 // Takes in a time stamp and returns the time ago something was (humanized)
 function timeAgo(timestamp) {
+  if (timestamp <= 0) return;
   return (
     humanizeDuration(Date.now() - timestamp * 1000, {
       largest: 1,


### PR DESCRIPTION
Simply adding conditionals for when the block height is == -1, to show 'pending' instead of linkable text. Also adding 'Pending' to the "Received" field, since the timestamp isn't provided correctly when a tx is in an unconfirmed state.