### PR TITLE
Using preexisting timeAgo function for scattered duration logic

### DIFF
--- a/src/templates/includes/listBlocks.pug
+++ b/src/templates/includes/listBlocks.pug
@@ -1,17 +1,16 @@
 - for (block of blocks)
-  - let duration = Math.floor(Date.now() / 1000) - block.time;
   - let minerAddress = block.coinbaseTx.outputs[0].address;
   tr
     td
       a.minerLinks(href="/block/" + block.height) #{block.height}
       div.is-hidden-tablet Size: #{block.size}
-    td.is-hidden-mobile #{humanizeDuration(duration * 1000, { round: true, largest: 1})} ago
+    td.is-hidden-mobile= timeAgo(block.time)
     td
       a.is-hidden-tablet.minerLinks(href="/address/" + minerAddress) #{truncateHash(minerAddress, 7)}
       //- .is-hidden-tablet #{truncateHash(minerAddress, 7)}
       a.is-hidden-mobile.minerLinks(href="/address/" + minerAddress) #{minerAddress}
       //- .is-hidden-mobile #{minerAddress}
-      div.is-hidden-tablet #{humanizeDuration(duration * 1000, { round: true, largest: 1})} ago
+      div.is-hidden-tablet= timeAgo(block.time)
     td.is-hidden-mobile #{block.size}
     td
       a.minerLinks(href="/txs?block=" + block.height) #{block.tx.length}

--- a/src/templates/includes/txCard.pug
+++ b/src/templates/includes/txCard.pug
@@ -20,7 +20,7 @@
             span.detailsText Miner Reward
           span.detailsText="Amount: " + prettyPrintHNS(tx.outputs[0].value)
         .summaryCardBlock.align-right
-          span="> " + humanizeDuration(Date.now() - tx.time * 1000, {largest: 1, round: true}) + " ago"
+          span="> " + timeAgo(tx.time)
           span.detailsText To: &nbsp;
             //- +tooltip("/address/" + tx.outputs[0].address, tx.outputs[0].address, true)
             a(href="/address/" + tx.outputs[0].address)=truncateHash(tx.outputs[0].address, 7)

--- a/src/templates/name.pug
+++ b/src/templates/name.pug
@@ -107,8 +107,7 @@ block content
           each tx in history
             tr
               td=tx.action
-              - let duration = Math.floor(Date.now() / 1000) -tx.time
-              td=humanizeDuration(duration * 1000, {round: true, largest: 1}) + " ago"
+              td=timeAgo(tx.time)
               td
                 a(href=`/block/${tx.height}`)=tx.height
               if tx.value

--- a/src/templates/peers.pug
+++ b/src/templates/peers.pug
@@ -49,7 +49,7 @@ block content
                       .stackedLabel Last Send / Last Received
                       if (peer.lastsend && peer.lastrecv)
                         .stackedElement
-                          =humanizeDuration(Date.now() - peer.lastsend * 1000, {largest: 1, round: true}) + " ago / " + humanizeDuration(Date.now() - peer.lastrecv * 1000, {largest: 1, round: true}) + " ago"
+                          =timeAgo(peer.lastsend) + " / " + timeAgo(peer.lastrecv)
                       else
                         .stackedElement N/A
   //- Could be added to its own file


### PR DESCRIPTION
https://github.com/HandshakeAlliance/HNScan/issues/21

Hand made duration logic was being used throughout the application. This PR will eliminate that by using the "timeAgo" template function in all these locations
- listBlocks.pug
- txCard.pug
- peers.pug
- names.pug
