### PR TITLE
search: convert search query to lowercase for name

### DIFF
--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -44,8 +44,9 @@ async function searchHandler(request, h) {
     }
   }
 
-  if (rules.verifyString(search)) {
-    let result = { type: "Name", url: `/name/${search}` };
+  let name = search.toLowerCase();
+  if (rules.verifyString(name)) {
+    let result = { type: "Name", url: `/name/${name}` };
     results.push(result);
   }
 


### PR DESCRIPTION
Currently if someone searches a name with an uppercase character on
HNScan it will bring them to an error page. Although this is technically
correct behavior, I have run into this issue multiple times where my
phone will autocorrect to a capital. I think by converting to lowercase
which is a valid HNS name, and then serving the user those results makes
for an easier UI/UX for everyone involved.

Fixes: #90 