### PR TITLE
util: update block reward to 2000

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -9,7 +9,7 @@ function currentBlockReward(blockHeight) {
   //Block halvening is 5000 blocks on Regtest
   let exponent = Math.floor(blockHeight / 340000);
 
-  let blockReward = 1000 / Math.pow(2, exponent);
+  let blockReward = 2000 / Math.pow(2, exponent);
 
   //Need to convert back to HNS
   return blockReward * 1000000;


### PR DESCRIPTION
testnet4 launched with a block reward of 2000. This is showing incorrect
answers for total fees and coinbase transactions on HNScan. This commit
updates the block reward calculation formula to account for this new
reward beginning