### PR TITLE
home: convert blocks card to new blocks api

### DIFF
--- a/src/handlers/home.js
+++ b/src/handlers/home.js
@@ -1,29 +1,21 @@
 const { getClient } = require("../util/clients.js");
 const { namesRegistered } = require("../util/util.js");
 
+const { getBlocks } = require("../api");
+
 async function homeHandler(request, h) {
   const client = getClient();
   const info = await client.getInfo();
 
   // blockSummary
   let blockHeight = info.chain.height;
-  let blocks = [];
-  var block;
+  let blocks;
 
-  for (var i = 0; i < Math.min(5, blockHeight); i++) {
-    try {
-      block = await client.execute("getblockbyheight", [
-        blockHeight - i,
-        true,
-        true
-      ]);
-      block.coinbaseTx = await client.getTX(block.tx[0].txid);
-      blocks.push(block);
-    } catch (e) {
-      console.log(e);
-    }
+  try {
+    blocks = await getBlocks(5, 0);
+  } catch (e) {
+    console.log(e);
   }
-  // end blockSummary
 
   //txSummary
   //Iterate through the lastest blocks, grab every transaction until you hit 4

--- a/src/templates/includes/blockCard.pug
+++ b/src/templates/includes/blockCard.pug
@@ -8,7 +8,6 @@
       .emptyStateSubheader The chain needs to be built
   else
     each block in blocks
-      - let miningAddress = block.coinbaseTx.outputs[0].address
       .summaryCardItem
         .summaryCardBlock
           .lineContainer
@@ -18,7 +17,7 @@
               a(href="/block/" + block.height)=block.height
           .lineContainer.detailsText Mined By:&nbsp;
             .is-hidden-mobile
-              a(href="/address/" + miningAddress)=miningAddress
+              a(href="/address/" + miningAddress)=block.minedBy
             .is-hidden-tablet
-              a(href="/address/" + miningAddress)=truncateHash(miningAddress, 7)
-          .summaryCardLine.detailsText="Block Reward: " + prettyPrintHNS(block.coinbaseTx.outputs[0].value)
+              a(href="/address/" + miningAddress)=truncateHash(block.minedBy, 7)
+          .summaryCardLine.detailsText="Block Reward: " + prettyPrintHNS(block.reward)


### PR DESCRIPTION
This commit changes the way that the front page gets the most recent 5
blocks by transitioning the api call to the new API format.