### PR TITLE
util: account for airdrops in getBlockTotalFees()

### DIFF
--- a/src/util/util.js
+++ b/src/util/util.js
@@ -1,6 +1,8 @@
 const { getClient } = require("./clients.js");
 const Covenant = require("hsd/lib/primitives/covenant");
 const rules = require("hsd/lib/covenants/rules");
+const {OwnershipProof} = require("hsd/lib/covenants/ownership");
+const AirdropProof = require("hsd/lib/primitives/airdropproof");
 const config = require("config");
 
 function currentBlockReward(blockHeight) {
@@ -24,14 +26,26 @@ function getBlockTotalFees(coinbaseTx, blockHeight) {
 
   var blockReward = currentBlockReward(blockHeight);
 
-  let totalOutput = 0;
+  const inputs = coinbaseTx.inputs;
+  const outputs = coinbaseTx.outputs;
 
-  for (let output of coinbaseTx.outputs) {
-    totalOutput += output.value;
+  // Start with the required coinbase output
+  let minerOutput = outputs[0].value;
+
+  for (let i = 1; i < outputs.length; i++) {
+    // Miner added extra subsidy payout outputs
+    if (!inputs[i]) {
+      minerOutput += outputs[i].value;
+    } else {
+      // let proof;
+      // try {
+      //   proof = AirdropProof.decode(Buffer.from(inputs[i].witness[0], "hex"));
+      // } catch (e) {
+      //   proof = OwnershipProof.decode(Buffer.from(inputs[i].witness[0], "hex"));
+    }
   }
 
-  let totalFees = totalOutput - blockReward;
-  return totalFees;
+  return minerOutput - blockReward;
 }
 
 function _formatName(nameHex) {


### PR DESCRIPTION
Not all coinbase outputs are miner subsidy payouts. An easy way to
tell is if the output has a corresponding input at the same index.
Besides index 0 (the reuired coinbase input and output) the presence
of an input and witness indicates an airdrop or claim proof.

Additional (optional) lines are commented out to expand this function
in the future if sepcific proof data is desired for the view.