### PR TITLE
jsconfig: add initial

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+      "baseUrl": "src"
+  },
+  "exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
This commit adds an initial jsconfig to the project. 

Essentially what this does is helps anyone using tsserver LSP autocomplete code from inside of the project, on top of a few other nice features. 

The second nice thing is this allows for us to have absolute imports. The documentation on this is here: https://create-react-app.dev/docs/importing-a-component/#absolute-imports. I will follow this up with another PR later on today converting most of our code to absolute imports.

More information on JSconfig can be found here: https://code.visualstudio.com/docs/languages/jsconfig