### PR TITLE
Collapsible cards

### DIFF
--- a/src/components/block/BlockAdvanced.js
+++ b/src/components/block/BlockAdvanced.js
@@ -12,7 +12,7 @@ export default function BlockAdvanced({ block }) {
   let [difficulty, exponent] = sciNotation(block.difficulty, 5);
   const { t } = useTranslation();
   return (
-    <Card title={t("Advanced")}>
+    <Card title={t("Advanced")} collapse closed>
       {/* @todo need auxilary labels -> bytes for size, scientific format for diff, etc */}
       <Row>
         <Col mobile={12} desktop>

--- a/src/components/name/NameAdvanced.js
+++ b/src/components/name/NameAdvanced.js
@@ -11,7 +11,7 @@ import { hnsValues } from "utils/util";
 export default function NameSummary({ name }) {
   const { t } = useTranslation();
   return (
-    <Card title={t("Advanced")}>
+    <Card title={t("Advanced")} collapse closed>
       {/* @todo need auxilary labels -> bytes for size, scientific format for diff, etc */}
       <Row>
         <Col mobile={12} desktop>

--- a/src/components/name/NameHistory.js
+++ b/src/components/name/NameHistory.js
@@ -22,7 +22,7 @@ export default function NameHistory({ history, page, changePage, pages, url }) {
   ));
   return (
     <>
-      <Card title="History">
+      <Card title="History" collapse>
         {/* @todo remove all these class names. */}
         {/* @todo need links in here */}
         {/* @todo need auxilary labels -> bytes for size, scientific format for diff, etc */}

--- a/src/containers/TransactionList.js
+++ b/src/containers/TransactionList.js
@@ -73,6 +73,7 @@ const TransactionList = ({ url, page, from }) => {
   return (
     <>
       <Card
+        collapse
         title={`${t("transaction", { count: txs.length })} (${offset +
           1}-${offset + txs.length})`}
       >

--- a/src/screens/Transaction.js
+++ b/src/screens/Transaction.js
@@ -58,7 +58,7 @@ function TxDetailScreen({ hash }) {
       </Card>
 
       {/* ------- Bottom Card ------ */}
-      <Card title="Advanced">
+      <Card title="Advanced" collapse closed>
         <Row>
           <Col mobile={12} desktop>
             <Table>
@@ -102,7 +102,7 @@ function TxDetailScreen({ hash }) {
         </Row>
       </Card>
 
-      <Card title="TX Activity">
+      <Card title="TX Activity" collapse>
         <Container>
           <Row>
             <Col mobile={12} desktop>


### PR DESCRIPTION
Adding the collapse property into select HNScan cards to hide advanced details by default and allow the user to choose to show/hide other sections of the site