### PR TITLE
chore: add URLs to the network switcher

### DIFF
--- a/src/components/shared/NetworkSwitcher.js
+++ b/src/components/shared/NetworkSwitcher.js
@@ -8,9 +8,18 @@ export default function NetworkSwitcher(props) {
   let [network, setNetwork] = useNetwork();
 
   let options = [
-    { value: "http://localhost:8080", label: "Local Testnet" },
-    { value: "https://api.hnscan.com", label: "HNScan Testnet" },
-    { value: "https://experimental.hnscan.com", label: "Experimental Testnet" }
+    {
+      value: "http://localhost:8080",
+      label: "Local Testnet (http://localhost:8080)"
+    },
+    {
+      value: "https://api.hnscan.com",
+      label: "HNScan Testnet (https://api.hnscan.com)"
+    },
+    {
+      value: "https://experimental.hnscan.com",
+      label: "Experimental Testnet (https://experimental.hnscan.com)"
+    }
   ];
 
   return (


### PR DESCRIPTION
This allows for a user to easily see what network they are attempting to connect to - not just the name of the network. Picture included: 
<img width="682" alt="Screen Shot 2019-12-16 at 8 20 03 PM" src="https://user-images.githubusercontent.com/9666345/70959314-8f751700-2041-11ea-8350-1fbde6feda8d.png">
