### PR TITLE
Change twitter link to Urkel Labs account

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -262,7 +262,7 @@ export default function Footer() {
                 {t("footer.medium")}
               </FooterLink>
               <FooterLink
-                href="https://twitter.com/hnsalliance"
+                href="https://twitter.com/UrkelLabs"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
Minor change to the site footer replacing the Twitter link from the suspended `@hnsalliance` account to the `@UrkelLabs` account.

This originates out of the suggestion made in issue #289. 